### PR TITLE
Specify extension type

### DIFF
--- a/box.json
+++ b/box.json
@@ -11,6 +11,7 @@
     },
     "bugs":"",
     "slug":"lucee-file-coverage",
+    "lucee-extension-releasetype":"web",
     "shortDescription":"This extension provides a debugging template that logs all the calls to script files as a test or QA person navigates your site. ",
     "description":"",
     "instructions":"",


### PR DESCRIPTION
This is required for the extension to be properly presented via the extension provider API as a "web" extension.  Right now, ForgeBox defaults to "server" if not specified.  
https://commandbox.ortusbooks.com/package-management/creating-packages/publishing-lucee-extensions-to-forgebox#advanced-properties

Ticket reference: 
https://luceeserver.atlassian.net/browse/LDEV-2286

If the extension can be installed in the server or web context, please change it "all".